### PR TITLE
Benchmark ImportError_repr

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2008,7 +2008,6 @@ class ImportErrorBenchmark(unittest.TestCase):
         # Create a big ImportError for testing
         missing_name = "some_missing_module"
         path_hint = "/this/is/a/fake/path/that/is/quite/long/and/descriptive"
-        exc = ImportError(f"Cannot import {missing_name}", name=missing_name, path=path_hint)
 
         # Define the code to benchmark
         stmt = "repr(ImportError('Cannot import some_missing_module', name='some_missing_module', path='/this/is/a/fake/path/that/is/quite/long/and/descriptive'))"
@@ -2016,7 +2015,6 @@ class ImportErrorBenchmark(unittest.TestCase):
         # Run benchmark
         iterations = 1_000_000  # Adjust for desired accuracy
         total_time = timeit.timeit(stmt, number=iterations)
-        avg_time = total_time / iterations
 
         print(f"Total time for creating ImportError: {total_time:.10f} seconds")
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2005,10 +2005,6 @@ class AttributeErrorTests(unittest.TestCase):
 
 class ImportErrorBenchmark(unittest.TestCase):
     def test_benchmark(self):         
-        # Create a big ImportError for testing
-        missing_name = "some_missing_module"
-        path_hint = "/this/is/a/fake/path/that/is/quite/long/and/descriptive"
-
         # Define the code to benchmark
         stmt = "repr(ImportError('Cannot import some_missing_module', name='some_missing_module', path='/this/is/a/fake/path/that/is/quite/long/and/descriptive'))"
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2005,10 +2005,8 @@ class AttributeErrorTests(unittest.TestCase):
 
 class ImportErrorBenchmark(unittest.TestCase):
     def test_benchmark(self):         
-        # Define the code to benchmark
         stmt = "repr(ImportError('Cannot import some_missing_module', name='some_missing_module', path='/this/is/a/fake/path/that/is/quite/long/and/descriptive'))"
 
-        # Run benchmark
         iterations = 1_000_000
         total_time = timeit.timeit(stmt, number=iterations)
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2009,7 +2009,7 @@ class ImportErrorBenchmark(unittest.TestCase):
         stmt = "repr(ImportError('Cannot import some_missing_module', name='some_missing_module', path='/this/is/a/fake/path/that/is/quite/long/and/descriptive'))"
 
         # Run benchmark
-        iterations = 1_000_000  # Adjust for desired accuracy
+        iterations = 1_000_000
         total_time = timeit.timeit(stmt, number=iterations)
 
         print(f"Total time for creating ImportError: {total_time:.10f} seconds")

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -20,6 +20,7 @@ from test.support.import_helper import import_module
 from test.support.os_helper import TESTFN, unlink
 from test.support.warnings_helper import check_warnings
 from test import support
+import timeit
 
 try:
     import _testcapi
@@ -2002,6 +2003,22 @@ class AttributeErrorTests(unittest.TestCase):
 
     # Note: name suggestion tests live in `test_traceback`.
 
+class ImportErrorBenchmark(unittest.TestCase):
+    def test_benchmark(self):         
+        # Create a big ImportError for testing
+        missing_name = "some_missing_module"
+        path_hint = "/this/is/a/fake/path/that/is/quite/long/and/descriptive"
+        exc = ImportError(f"Cannot import {missing_name}", name=missing_name, path=path_hint)
+
+        # Define the code to benchmark
+        stmt = "repr(ImportError('Cannot import some_missing_module', name='some_missing_module', path='/this/is/a/fake/path/that/is/quite/long/and/descriptive'))"
+
+        # Run benchmark
+        iterations = 1_000_000  # Adjust for desired accuracy
+        total_time = timeit.timeit(stmt, number=iterations)
+        avg_time = total_time / iterations
+
+        print(f"Total time for creating ImportError: {total_time:.10f} seconds")
 
 class ImportErrorTests(unittest.TestCase):
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1868,54 +1868,80 @@ static PyObject *
 ImportError_repr(PyObject *self)
 {
     int hasargs = PyTuple_GET_SIZE(((PyBaseExceptionObject *)self)->args) != 0;
-    PyImportErrorObject *exc = PyImportErrorObject_CAST(self);
-    PyUnicodeWriter *writer = PyUnicodeWriter_Create(0);
-    if (writer == NULL) {
-        goto error;
-    }
     PyObject *r = BaseException_repr(self);
-    if (r == NULL) {
-        goto error;
-    }
-    if (PyUnicodeWriter_WriteSubstring(
-        writer, r, 0, PyUnicode_GET_LENGTH(r) - 1) < 0)
-    {
-        Py_XDECREF(r);
-        goto error;
-    }
-    Py_XDECREF(r);
-    if (exc->name) {
-        if (hasargs) {
-            if (PyUnicodeWriter_WriteASCII(writer, ", ", 2) < 0) {
-                goto error;
-            }
-        }
-        if (PyUnicodeWriter_Format(writer, "name=%R", exc->name) < 0) {
-            goto error;
-        }
-        hasargs = 1;
-    }
-    if (exc->path) {
-        if (hasargs) {
-            if (PyUnicodeWriter_WriteASCII(writer, ", ", 2) < 0) {
-                goto error;
-            }
-        }
-        if (PyUnicodeWriter_Format(writer, "path=%R", exc->path) < 0) {
-            goto error;
-        }
-    }
+    PyImportErrorObject *exc = PyImportErrorObject_CAST(self);
 
-    if (PyUnicodeWriter_WriteChar(writer, ')') < 0) {
-        goto error;
+    if (r && (exc->name || exc->path)) {
+        /* remove ')' */
+        Py_SETREF(r, PyUnicode_Substring(r, 0, PyUnicode_GET_LENGTH(r) - 1));
+        if (r && exc->name) {
+            Py_SETREF(r, PyUnicode_FromFormat("%U%sname=%R",
+                            r, hasargs ? ", " : "", exc->name));
+            hasargs = 1;
+        }
+        if (r && exc->path) {
+            Py_SETREF(r, PyUnicode_FromFormat("%U%spath=%R",
+                            r, hasargs ? ", " : "", exc->path));
+        }
+        if (r) {
+            Py_SETREF(r, PyUnicode_FromFormat("%U)", r));
+        }
     }
-
-    return PyUnicodeWriter_Finish(writer);
-
-error:
-    PyUnicodeWriter_Discard(writer);
-    return NULL;
+    return r;
 }
+
+// static PyObject *
+// ImportError_repr(PyObject *self)
+// {
+//     int hasargs = PyTuple_GET_SIZE(((PyBaseExceptionObject *)self)->args) != 0;
+//     PyImportErrorObject *exc = PyImportErrorObject_CAST(self);
+//     PyUnicodeWriter *writer = PyUnicodeWriter_Create(0);
+//     if (writer == NULL) {
+//         goto error;
+//     }
+//     PyObject *r = BaseException_repr(self);
+//     if (r == NULL) {
+//         goto error;
+//     }
+//     if (PyUnicodeWriter_WriteSubstring(
+//         writer, r, 0, PyUnicode_GET_LENGTH(r) - 1) < 0)
+//     {
+//         Py_XDECREF(r);
+//         goto error;
+//     }
+//     Py_XDECREF(r);
+//     if (exc->name) {
+//         if (hasargs) {
+//             if (PyUnicodeWriter_WriteASCII(writer, ", ", 2) < 0) {
+//                 goto error;
+//             }
+//         }
+//         if (PyUnicodeWriter_Format(writer, "name=%R", exc->name) < 0) {
+//             goto error;
+//         }
+//         hasargs = 1;
+//     }
+//     if (exc->path) {
+//         if (hasargs) {
+//             if (PyUnicodeWriter_WriteASCII(writer, ", ", 2) < 0) {
+//                 goto error;
+//             }
+//         }
+//         if (PyUnicodeWriter_Format(writer, "path=%R", exc->path) < 0) {
+//             goto error;
+//         }
+//     }
+
+//     if (PyUnicodeWriter_WriteChar(writer, ')') < 0) {
+//         goto error;
+//     }
+
+//     return PyUnicodeWriter_Finish(writer);
+
+// error:
+//     PyUnicodeWriter_Discard(writer);
+//     return NULL;
+// }
 
 static PyMemberDef ImportError_members[] = {
     {"msg", _Py_T_OBJECT, offsetof(PyImportErrorObject, msg), 0,


### PR DESCRIPTION
## Description

small test to bechmark ImportError_repr's alternative implementations as requested per https://github.com/python/cpython/pull/136770#issuecomment-3183083533

## How to run ?

1. uncomment the implementation you want to benchmark in exceptions.c (comment the other one)
2. build cpython (e.g run `make`)
3. run `./python.exe -m test test_exceptions -m ImportErrorBenchmark -v` , the benchmark result should appear as a stdout print.

## Results

as run on my m2 macbook pro:

PyUnicodeWriter implementation:  `Total time for creating ImportError: 1.9643223330 seconds`

Alternative implementation: `Total time for creating ImportError: 2.4935530830 seconds`